### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/blush/blush_test.go
+++ b/blush/blush_test.go
@@ -482,11 +482,9 @@ func testBlushStdinPrintName(t *testing.T) {
 	t.Parallel()
 	input := "line one"
 	oldStdin := os.Stdin
-	f, err := ioutil.TempFile("", "blush_stdin")
+	f, err := ioutil.TempFile(t.TempDir(), "blush_stdin")
 	assert.NoError(t, err)
 	defer func() {
-		err := os.Remove(f.Name())
-		assert.NoError(t, err)
 		os.Stdin = oldStdin
 	}()
 	os.Stdin = f
@@ -507,16 +505,12 @@ func testBlushStdinPrintName(t *testing.T) {
 
 func testBlushPrintFilename(t *testing.T) {
 	t.Parallel()
-	p, err := ioutil.TempDir("", "blush_name")
-	assert.NoError(t, err)
+	p := t.TempDir()
 	f1, err := ioutil.TempFile(p, "blush_name")
 	assert.NoError(t, err)
 	f2, err := ioutil.TempFile(p, "blush_name")
 	assert.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(p)
-		assert.NoError(t, err)
-	}()
+
 	line1 := "line one\n"
 	line2 := "line two\n"
 	f1.WriteString(line1)

--- a/cmd/args_test.go
+++ b/cmd/args_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/ioutil"
-	"os"
 	"path"
 	"testing"
 
@@ -73,12 +72,7 @@ func TestArgsPipe(t *testing.T) {
 }
 
 func TestArgsPaths(t *testing.T) {
-	dir, err := ioutil.TempDir("", "blush_main")
-	assert.NoError(t, err)
-	defer func() {
-		err := os.RemoveAll(dir)
-		assert.NoError(t, err)
-	}()
+	dir := t.TempDir()
 	f1, err := ioutil.TempFile(dir, "main")
 	assert.NoError(t, err)
 	f2, err := ioutil.TempFile(dir, "main")

--- a/cmd/helper_test.go
+++ b/cmd/helper_test.go
@@ -31,14 +31,13 @@ func (s *stdFile) Close() error {
 
 func newStdFile(t *testing.T, name string) *stdFile {
 	t.Helper()
-	f, err := ioutil.TempFile("", name)
+	f, err := ioutil.TempFile(t.TempDir(), name)
 	if err != nil {
 		t.Fatal(err)
 	}
 	sf := &stdFile{f}
 	t.Cleanup(func() {
 		f.Close()
-		os.Remove(f.Name())
 	})
 	return sf
 }
@@ -69,15 +68,10 @@ func setup(t *testing.T, args string) (stdout, stderr *stdFile) {
 
 func getPipe(t *testing.T) *os.File {
 	t.Helper()
-	file, err := ioutil.TempFile("", "blush_pipe")
+	file, err := ioutil.TempFile(t.TempDir(), "blush_pipe")
 	assert.NoError(t, err)
 	name := file.Name()
 	file.Close()
-
-	t.Cleanup(func() {
-		err = os.Remove(name)
-		assert.NoError(t, err)
-	})
 
 	file, err = os.OpenFile(name, os.O_CREATE|os.O_RDWR, os.ModeCharDevice|os.ModeDevice)
 	assert.NoError(t, err)

--- a/cmd/main_internal_test.go
+++ b/cmd/main_internal_test.go
@@ -13,21 +13,15 @@ func getPipe(t *testing.T) *os.File {
 	t.Helper()
 	oldStdin := os.Stdin
 
-	file, err := ioutil.TempFile("", "blush_pipe")
+	file, err := ioutil.TempFile(t.TempDir(), "blush_pipe")
 	assert.NoError(t, err)
 	name := file.Name()
-	rmFile := func() {
-		err := os.Remove(name)
-		assert.NoError(t, err)
-	}
 	file.Close()
-	rmFile()
 	file, err = os.OpenFile(name, os.O_CREATE|os.O_RDWR, os.ModeCharDevice|os.ModeDevice)
 	assert.NoError(t, err)
 	os.Stdin = file
 	t.Cleanup(func() {
 		os.Stdin = oldStdin
-		rmFile()
 	})
 	return file
 }
@@ -45,15 +39,7 @@ func stringSliceEq(a, b []string) bool {
 }
 
 func TestFiles(t *testing.T) {
-	dir, err := ioutil.TempDir("", "blush_main")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		if err = os.RemoveAll(dir); err != nil {
-			t.Error(err)
-		}
-	}()
+	dir := t.TempDir()
 	f1, err := ioutil.TempFile(dir, "main")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/reader/helper_test.go
+++ b/internal/reader/helper_test.go
@@ -2,7 +2,6 @@ package reader_test
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -26,13 +25,12 @@ type testCase struct {
 
 func setup(t *testing.T, input []testCase) []string {
 	t.Helper()
-	dir, err := ioutil.TempDir("", "blush_walker")
-	assert.NoError(t, err)
+	dir := t.TempDir()
 	ret := make([]string, len(input))
 	for i, d := range input {
 		name := path.Join(dir, d.name)
 		base := path.Dir(name)
-		err = os.MkdirAll(base, os.ModePerm)
+		err := os.MkdirAll(base, os.ModePerm)
 		assert.NoError(t, err)
 		f, err := os.Create(name)
 		assert.NoError(t, err)
@@ -40,10 +38,6 @@ func setup(t *testing.T, input []testCase) []string {
 		f.Close()
 		ret[i] = base
 	}
-	t.Cleanup(func() {
-		err := os.RemoveAll(dir)
-		assert.NoError(t, err)
-	})
 
 	return ret
 }


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer require.NoError(os.RemoveAll(tmpDir))

	// now
	tmpDir := t.TempDir()
}
```